### PR TITLE
Changing FloatingLabelWidgetBase to work fine with android:animateLayoutChanges

### DIFF
--- a/demo/src/main/java/com/marvinlabs/widget/floatinglabel/demo/AnimateLayoutChangesCompatFragment.java
+++ b/demo/src/main/java/com/marvinlabs/widget/floatinglabel/demo/AnimateLayoutChangesCompatFragment.java
@@ -1,0 +1,57 @@
+package com.marvinlabs.widget.floatinglabel.demo;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.Toast;
+
+import com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText;
+import com.marvinlabs.widget.slideshow.demo.R;
+
+
+public class AnimateLayoutChangesCompatFragment extends Fragment implements FloatingLabelEditText.EditTextListener {
+
+    public static AnimateLayoutChangesCompatFragment newInstance() {
+        return new AnimateLayoutChangesCompatFragment();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_animate_layout_changes_compat, null, false);
+
+        ((FloatingLabelEditText) root.findViewById(R.id.edit_text1)).setEditTextListener(this);
+        ((FloatingLabelEditText) root.findViewById(R.id.edit_text2)).setEditTextListener(this);
+        ((FloatingLabelEditText) root.findViewById(R.id.edit_text3)).setEditTextListener(this);
+        ((FloatingLabelEditText) root.findViewById(R.id.edit_text4)).setEditTextListener(this);
+
+        final ViewGroup viewGroup = (ViewGroup) root.findViewById(R.id.layout);
+
+        Button button = (Button) root.findViewById(R.id.buttonTry);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                changeViewGroupVisibility(viewGroup);
+            }
+        });
+
+        return root;
+    }
+
+    private void changeViewGroupVisibility(ViewGroup viewGroup) {
+        if (viewGroup.getVisibility() == View.VISIBLE) {
+            viewGroup.setVisibility(View.GONE);
+        } else {
+            viewGroup.setVisibility(View.VISIBLE);
+        }
+    }
+
+    @Override
+    public void onTextChanged(FloatingLabelEditText source, String text) {
+        Toast.makeText(getActivity(), text, Toast.LENGTH_SHORT).show();
+    }
+}

--- a/demo/src/main/java/com/marvinlabs/widget/floatinglabel/demo/DemoListFragment.java
+++ b/demo/src/main/java/com/marvinlabs/widget/floatinglabel/demo/DemoListFragment.java
@@ -20,6 +20,7 @@ public class DemoListFragment extends android.support.v4.app.ListFragment {
 
     public static final Demo[] DEMOS = new Demo[]{
             new Demo("EditText widgets", TextWidgetsFragment.class),
+            new Demo("Animate Layout Changes Compatibility", AnimateLayoutChangesCompatFragment.class),
             new Demo("AutoComplete widgets", AutoCompleteWidgetsFragment.class),
             new Demo("Item picker widgets", ItemWidgetsFragment.class),
             new Demo("Instant picker widgets", InstantWidgetsFragment.class),

--- a/demo/src/main/res/layout/fragment_animate_layout_changes_compat.xml
+++ b/demo/src/main/res/layout/fragment_animate_layout_changes_compat.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.marvinlabs.widget.floatinglabel.demo.MainActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/buttonTry"
+            android:text="Try animation"/>
+
+        <LinearLayout
+            android:id="@+id/layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText
+                android:id="@+id/edit_text1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="15dp"
+                app:flw_labelText="Simple text input" />
+
+            <com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText
+                android:id="@+id/edit_text2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="15dp"
+                android:drawableLeft="@drawable/ic_lock"
+                android:drawablePadding="10dp"
+                android:inputType="textPassword"
+                app:flw_labelText="Password input" />
+
+            <com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText
+                android:id="@+id/edit_text3"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="15dp"
+                android:drawablePadding="10dp"
+                android:inputType="textMultiLine"
+                app:flw_labelText="Multiline input" />
+
+            <com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText
+                android:id="@+id/edit_text4"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="15dp"
+                app:flw_labelText="Custom text sizes &amp; colors"
+                app:flw_labelTextColor="@android:color/holo_blue_dark"
+                app:flw_inputWidgetTextColor="@android:color/holo_green_dark"
+                app:flw_labelTextSize="18sp"
+                app:flw_inputWidgetTextSize="26sp"/>
+
+            <com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText
+                android:id="@+id/edit_text6"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="15dp"
+                app:flw_labelText="Float on focus change"
+                app:flw_floatOnFocus="true"/>
+
+            <com.marvinlabs.widget.floatinglabel.edittext.FloatingLabelEditText
+                android:id="@+id/edit_text7"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="15dp"
+                app:flw_labelText="Float on value not empty"
+                app:flw_floatOnFocus="false"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -47,7 +47,6 @@ android.libraryVariants.all { variant ->
     task("javadoc${variant.name.capitalize()}", type: Javadoc) {
         description "Generates Javadoc for $variant.name."
         source = variant.javaCompile.source
-
     }
 
     task("bundleJavadoc${variant.name.capitalize()}", type: Jar) {
@@ -59,7 +58,7 @@ android.libraryVariants.all { variant ->
 
 task sourcesJar(type: Jar) {
     classifier = 'sources'
-    from android.sourceSets.main.java
+    from android.sourceSets.main.java.srcDirs
 }
 
 task jar(type: Jar) {

--- a/library/library.iml
+++ b/library/library.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.marvinlabs" external.system.module.version="1.5.0-6-g5d290cd-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.marvinlabs" external.system.module.version="1.6.0-1-g347fe93-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -62,6 +62,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -81,6 +82,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>

--- a/library/src/main/java/com/marvinlabs/widget/floatinglabel/FloatingLabelWidgetBase.java
+++ b/library/src/main/java/com/marvinlabs/widget/floatinglabel/FloatingLabelWidgetBase.java
@@ -11,6 +11,7 @@ import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.TextView;
@@ -568,12 +569,14 @@ public abstract class FloatingLabelWidgetBase<InputWidgetT extends View> extends
         getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
-                isLaidOut = true;
-                setInitialWidgetState();
-                if (Build.VERSION.SDK_INT >= 16) {
-                    getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                } else {
-                    getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                if (getParentVisibility() == View.VISIBLE) {
+                    isLaidOut = true;
+                    setInitialWidgetState();
+                    if (Build.VERSION.SDK_INT >= 16) {
+                        getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    } else {
+                        getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                    }
                 }
             }
         });
@@ -582,6 +585,14 @@ public abstract class FloatingLabelWidgetBase<InputWidgetT extends View> extends
         // adding children
         initCompleted = true;
         onInitCompleted();
+    }
+
+    /**
+     * Return the visibility of the parent ViewGroup
+     * @return
+     */
+    private int getParentVisibility() {
+        return getRootView().findViewById(((ViewGroup)getParent()).getId()).getVisibility();
     }
 
     /**


### PR DESCRIPTION
Before, the float label text was displayed cut.
Now, ViewTreeObserver.OnGlobalLayoutListener.onGlobalLayout() only works if parent visibility is equal View.VISIBLE.

The new Fragment and /layout/fragment....xml are optionals. They are used to demonstrate the problem and the fix. See atached images, please.

BEFORE
![before](https://cloud.githubusercontent.com/assets/1694366/7289002/4949cc86-e940-11e4-821c-5c2cb8cea0a7.png)

AFTER
![after](https://cloud.githubusercontent.com/assets/1694366/7289003/494a8090-e940-11e4-8170-6b5875b2317b.png)